### PR TITLE
Fixing config variables names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ fast, mini, simple
 
 ```viml
   hi Marks ctermfg=80
-  let s:mark_ns_id = [number]  " default 9898
-  let s:mark_priority = [number] " default 999
-  let s:enabled_marks = "[string]" default '[a-zA-Z]'
+  let g:mark_ns_id = [number]  " default 9898
+  let g:mark_priority = [number] " default 999
+  let g:enabled_marks = "[string]" default '[a-zA-Z]'
 ```


### PR DESCRIPTION
Hello,

Thanks for your plugin! I started using it today and tried to configure it according to README, but found out that it should be `g:` instead of `s:`, so here's a PR to change it.

Hope you like it!

Thanks,
André